### PR TITLE
Remove unused smart_unicode import

### DIFF
--- a/admin_steroids/fields.py
+++ b/admin_steroids/fields.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     # Renamed in Django 1.9.
     from django.forms.utils import ValidationError 
-from django.utils.encoding import DjangoUnicodeDecodeError, force_unicode
+from django.utils.encoding import DjangoUnicodeDecodeError, force_text
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _, ugettext as _
@@ -126,7 +126,7 @@ class CurrencyInput(forms.widgets.TextInput):
                 value = Currency(value).format_pretty()
             except Exception as e:
                 pass
-            final_attrs['value'] = force_unicode(value)
+            final_attrs['value'] = force_text(value)
 
         return mark_safe(u'<input%s />' % flatatt(final_attrs))
 

--- a/admin_steroids/filters.py
+++ b/admin_steroids/filters.py
@@ -9,7 +9,7 @@ from django.db import models
 from django.db.models import Q
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
-from django.utils.encoding import smart_unicode, smart_text, force_text
+from django.utils.encoding import smart_text, force_text
 from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib.auth.models import User
 

--- a/admin_steroids/widgets.py
+++ b/admin_steroids/widgets.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.forms.widgets import Select, TextInput, flatatt
 from django.template import Context, Template
 from django.template.context import Context
-from django.utils.encoding import force_unicode, smart_unicode
+from django.utils.encoding import force_text, smart_text
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
@@ -65,7 +65,7 @@ class ForeignKeyTextInput(TextInput):
         final_attrs = self.build_attrs(attrs, type=self.input_type, name=name)
         if value != '':
             # Only add the 'value' attribute if a value is non-empty.
-            final_attrs['value'] = force_unicode(self._format_value(value))
+            final_attrs['value'] = force_text(self._format_value(value))
         final_attrs['size'] = 10
         t = Template(u"""
 {% load staticfiles %}
@@ -145,7 +145,7 @@ class VerboseManyToManyRawIdWidget(ManyToManyRawIdWidget):
         for v in values:
             obj = self.rel.to._default_manager\
                 .using(self.db).get(**{key: v})
-            x = smart_unicode(obj)
+            x = smart_text(obj)
             try:
                 change_url = reverse(
                     "admin:%s_%s_change" \


### PR DESCRIPTION
The smart_unicode import is not used and it breaks on Python3.

I have removed only this one as it was sufficient (so far) for my usecase but if you ran flake8 on the codebase you'll find out tons of unused imports.